### PR TITLE
Try/except wrapper for Recipe get_serializer_context

### DIFF
--- a/brewkeeper/api/views.py
+++ b/brewkeeper/api/views.py
@@ -45,15 +45,17 @@ class RecipeViewSet(viewsets.ModelViewSet):
         return context
 
     def get_serializer_class(self):
-        if self.kwargs['user_username'] == 'public':
+        try:
+            if self.kwargs['user_username'] == 'public':
+                if self.action is 'list':
+                    return api_serializers.PublicRecipeListSerializer
+                else:
+                    return api_serializers.PublicRecipeDetailSerializer
+        except:
             if self.action is 'list':
-                return api_serializers.PublicRecipeListSerializer
+                return api_serializers.RecipeListSerializer
             else:
-                return api_serializers.PublicRecipeDetailSerializer
-        if self.action is 'list':
-            return api_serializers.RecipeListSerializer
-        else:
-            return api_serializers.RecipeDetailSerializer
+                return api_serializers.RecipeDetailSerializer
 
 
 


### PR DESCRIPTION
Swagger was giving a 500 Internal Server Error on the users endpoint.
- [x] Wrapped the RecipeViewSet's get_serializer_context in try/except to catch the error
